### PR TITLE
Use empty template parameter list

### DIFF
--- a/src/directx/d2d1_1.d
+++ b/src/directx/d2d1_1.d
@@ -2231,7 +2231,7 @@ extern(Windows)
 // public import D2D1 = directx.d2d1_1helper; TODO: Resolve namespace translation
 
 HRESULT 
-D2D1CreateDevice(T=void)(
+D2D1CreateDevice()(
     IDXGIDevice dxgiDevice,
     const D2D1_CREATION_PROPERTIES creationProperties,
     out ID2D1Device d2dDevice
@@ -2246,7 +2246,7 @@ D2D1CreateDevice(T=void)(
 } 
     
 HRESULT 
-D2D1CreateDeviceContext(T=void)(
+D2D1CreateDeviceContext()(
     IDXGISurface dxgiSurface,
     const D2D1_CREATION_PROPERTIES creationProperties,
     out ID2D1DeviceContext d2dDeviceContext


### PR DESCRIPTION
I confirmed that both versions fix the undefined symbol issue.  This one seems cleaner to me, up to you whether or not to pull.